### PR TITLE
update exceljs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "exceljs": "^0.2.39",
+    "exceljs": "^1.6.2",
     "joi": "^10.2.0",
     "lodash": "^4.17.4"
   }


### PR DESCRIPTION
Update Version of exceljs to a recent version ot make the lib usable in the electronjs framework. With the old version it throws an error because auf an deprecated version of graceful-fs.